### PR TITLE
Fix compatibility with YARP 2.3.72

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ cmake_minimum_required(VERSION 3.5)
 
 project(ICUBcontrib NONE)
 
-set(YARP_REQUIRED_VERSION 3.0.0)
+set(YARP_REQUIRED_VERSION 2.3.72)
 find_package(YARP REQUIRED)
 if(${YARP_VERSION} VERSION_LESS ${YARP_REQUIRED_VERSION})
   message(FATAL_ERROR "YARP version ${YARP_VERSION} not sufficient, at least version ${YARP_REQUIRED_VERSION} is required.")


### PR DESCRIPTION
The automatic inclusion of `YarpInstallationHelpers` is available since YARP 2.3.70
, see https://github.com/robotology/yarp/blob/12c945deef2bb4d24cc5825ceed4570eb22bae17/doc/release/v2_3_70.md#cmake-modules , so there is no reason to break compatibility with YARP 2.3.72 .